### PR TITLE
Fix illegal unlink on a directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function cleanDirectory(directory, ignore, exclude) {
 
   // remove directory if no ignored path
   if (!nbIgnored) {
-    fs.unlinkSync(directory)
+    fs.rmdirSync(directory)
     return true
   }
 


### PR DESCRIPTION
Use rmdirSync instead of unlinkSync in cleanDirectory, solving this error:

```
Error: EISDIR: illegal operation on a directory, unlink '.../static/media'
    at Error (native)
    at Object.fs.unlinkSync (fs.js:1089:18)
    at cleanDirectory (webpack-clean-manifest-plugin/lib/index.js:83:18)
    at cleanPath (webpack-clean-manifest-plugin/lib/index.js:103:54)
```
